### PR TITLE
Problem: fix(#21) cargo clippy warning with  feature

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+enum-variant-size-threshold = 500


### PR DESCRIPTION
solution: add `.clippy.toml` to config the clippy strategy.