### PR TITLE
Problem: (fix #18) upgrade secp256k1 to 0.20 fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,12 +81,6 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-
-[[package]]
-name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
@@ -207,7 +201,6 @@ dependencies = [
  "rand 0.8.2",
  "regex",
  "reqwest",
- "secp256k1",
  "serde",
  "serde_json",
  "signature",
@@ -760,7 +753,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "hashbrown",
 ]
 
@@ -934,7 +927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -1012,7 +1005,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -1072,7 +1065,7 @@ version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -1328,24 +1321,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_pcg",
- "rand_xorshift",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -1367,16 +1342,6 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rand_core 0.6.1",
  "rand_hc 0.3.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1434,15 +1399,6 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
@@ -1457,45 +1413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core 0.6.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1659,7 +1576,6 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
 dependencies = [
- "rand 0.6.5",
  "secp256k1-sys",
 ]
 
@@ -1968,7 +1884,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca04cec6ff2474c638057b65798f60ac183e5e79d3448bb7163d36a39cff6ec"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "bytes 1.0.1",
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ autoexamples = false
 serde = { version = "1.0", features = ["derive"], optional = true }
 sorted-json = { version = "0.1", optional = true }
 serde_json = { version = "1.0", optional = true }
-secp256k1 = { version = "0.17", default-features = false, features = ["rand"] }
 tiny-bip39 = "0.8"
 anyhow = { version = "1.0", features = ["std"] }
 hdwallet = "0.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use crate::hd_wallet::mnemonic::MnemonicError;
+use hdwallet::secp256k1;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/key_service/ledger_service.rs
+++ b/src/key_service/ledger_service.rs
@@ -1,8 +1,8 @@
 use crate::ledger_app::CryptoApp;
 use crate::ledger_app::PubkeyAddress;
 use async_trait::async_trait;
+use hdwallet::secp256k1::PublicKey as InnerPublicKey;
 use ledger_transport::APDUTransport;
-use secp256k1::PublicKey as InnerPublicKey;
 use std::sync::Arc;
 use zx_bip44::BIP44Path;
 

--- a/src/key_service/private_key_service.rs
+++ b/src/key_service/private_key_service.rs
@@ -6,7 +6,7 @@ use crate::key_service::KeyService;
 use async_trait::async_trait;
 use bitcoin_hashes::{ripemd160, sha256};
 use bitcoin_hashes::{Hash, HashEngine};
-use secp256k1::Message;
+use hdwallet::secp256k1::{Message, Secp256k1};
 use stdtx::address::{Address, ADDRESS_SIZE};
 
 /// stores private key
@@ -33,7 +33,7 @@ impl PrivateKeyService {
         engine.input(msg);
         let hash = sha256::Hash::from_engine(engine);
         let message = Message::from_slice(hash.as_inner())?;
-        let signer = secp256k1::Secp256k1::signing_only();
+        let signer = Secp256k1::signing_only();
         let signature = signer.sign(&message, self.private_key.as_ref());
         let raw = signature.serialize_compact();
         let signature_str = base64::encode(&raw);

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
+use hdwallet::secp256k1;
 use hdwallet::ExtendedPrivKey;
-use secp256k1::rand::Rng;
 use secp256k1::{All, Secp256k1};
 use secp256k1::{Error as SecpError, PublicKey as InnerPublicKey, SecretKey};
 use serde::Serialize;
@@ -38,11 +38,6 @@ impl AsRef<SecretKey> for PrivateKey {
 }
 
 impl PrivateKey {
-    pub fn new<R: Rng + ?Sized>(rng: &mut R) -> Self {
-        let secret_key = SecretKey::new(rng);
-        Self(secret_key)
-    }
-
     pub fn from_slice(slice: &[u8]) -> Result<Self, SecpError> {
         let secret_key = SecretKey::from_slice(slice)?;
         Ok(Self(secret_key))


### PR DESCRIPTION
use the one in `hdwallet` crate directly.