### PR TITLE
Problem: (fix #20) cargo test fails to compile with  feature "--features=grpc"

### DIFF
--- a/.github/workflows/chainlib.yml
+++ b/.github/workflows/chainlib.yml
@@ -63,6 +63,8 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --target ${{ matrix.target }} --release --all-features
+      - run: cargo build --target ${{ matrix.target }} --release --example amino
+      - run: cargo build --target ${{ matrix.target }} --release --example protobuf --features=grpc
 
   test:
     runs-on: ubuntu-latest
@@ -79,4 +81,4 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo test --release
+      - run: cargo test --release --lib --all-features

--- a/README.md
+++ b/README.md
@@ -35,3 +35,6 @@ chain-maind tx bank send \
 or 
 
 `cargo build --example protobuf --features=grpc`
+
+# unit test
+`cargo test --lib --all-features`


### PR DESCRIPTION
according to the [Rust document](https://doc.rust-lang.org/cargo/commands/cargo-test.html), if no binary options are given, rust will build all the examples, but the `amino` feature and `grpc` feature can not build at the same time, so just given `--lib` when test.